### PR TITLE
Update keep.R

### DIFF
--- a/R/keep.R
+++ b/R/keep.R
@@ -7,36 +7,37 @@
 #' @param x A character vector of variables which you wish to keep
 #' 
 #' @details
-#' The function uses the \code{ls} command to find the variables that are defined in the global environment. It then deletes all variables that are not given as an argument.
+#' The function uses the \code{ls} command to find the variables that are defined in the parent environment. It then deletes all variables that are not given as an argument.
 #' 
 #' @author Michael Floren
 #' 
 #  For whatever reason, I CANNOT get this link to the "rm" function to actually create a hyperlink
 #' @seealso \code{\link{rm}}
 #' 
-
-
-# note that in order to read the environment of all of the variables, we need to say "ls(name=.GlobalEnv)" (as just saying "ls()" would just give the variables that are defined in the function environment)
-
-keep <- function(...,x=c())
+keep <- function(..., x = c())
 {
   
-  if(length(x))
+  if (length(x) > 0)
   {
-    if(!is.character(x)) stop("x must contain character vector")
-    rm(list=ls(name=.GlobalEnv)[!ls(name=.GlobalEnv)%in%x], pos=.GlobalEnv)
-    return(invisible(ls(name=.GlobalEnv)))
+    if (!is.character(x)) 
+      stop("x must contain character vector")
+    
+    L <- ls(name = parent.frame())
+    rm(list = L[!L %in% x], pos = parent.frame())
+    
+    return(invisible(ls(name = parent.frame())))
   }
   
-  dots <- match.call(expand.dots=FALSE)$...
+  dots <- match.call(expand.dots = FALSE)$...
   
   if (length(dots) && !all(sapply(dots, function(x) is.symbol(x) || 
-                                    is.character(x)))) 
+                                  is.character(x)))) 
     stop("... must contain names or character strings")
   
-  names <- sapply(dots,as.character)
+  names <- sapply(dots, as.character)
+  L <- ls(name = parent.frame())
+  rm(list = L[!L %in% names], pos = parent.frame())
   
-  rm(list=ls(name=.GlobalEnv)[!ls(name=.GlobalEnv) %in% names], pos=.GlobalEnv)
+  return(invisible(ls(name = parent.frame())))
   
-  invisible(ls(name=.GlobalEnv))
 }


### PR DESCRIPTION
Updated keep function in order to work inside functions, thus removing and keeping variables of the function environment in which it is called. For example:

foo <- function() {

  a <- 1
  b <- 2
  c <- 3
  keep(a)
  print(a)
  print(b)

}

Calling foo() will generate an error since "b" is deleted, only "a" is kept inside foo().

This also works for the global env:
a <- 1
b <- 2
c <- 3
keep(a)
print(a)
print(b)
ls()

will generate an error when trying to print the non-existing "b", and list only "a" in the environment.
